### PR TITLE
feat: add header with menu links (#2)

### DIFF
--- a/docs/design/DetailDesign/contents/header.md
+++ b/docs/design/DetailDesign/contents/header.md
@@ -40,6 +40,8 @@
   - items: Array<{ label: string; to: string; }>
 - 出力（見た目/挙動）
   - itemsの順番どおりにリンクを表示
+  - リンクの表示は、均等割で表示
+    - 例: `ul` を `display:flex` にし、各 `li` を `flex: 1`（同じ幅）として中央寄せする
   - クリックで react-router 経由でページ遷移
   - active表現（選択中スタイル）は「やる/やらない」を仕様で明記（未指定ならやらない）
   - propsにthemeやsizeを渡すことで、タイトル文字の色やサイズを変更できること

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,7 +8,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
-export default defineConfig([globalIgnores(['dist']), {
+export default defineConfig([globalIgnores(['dist', 'storybook-static']), {
   files: ['**/*.{ts,tsx}'],
   extends: [
     js.configs.recommended,

--- a/frontend/src/components/uiParts/HeaderMenu/presenter.tsx
+++ b/frontend/src/components/uiParts/HeaderMenu/presenter.tsx
@@ -21,15 +21,16 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
 
   return (
     <nav aria-label="Header menu">
-      <ul className="flex flex-row space-x-4 md:justify-around max-md:gap-2">
+      <ul className="flex w-full flex-row">
         {props.items.map((item) => {
           return (
-            <li key={item.label}>
+            <li key={item.label} className="flex-1 text-center">
               <RouterLinkItem
                 text={item.label}
                 link={item.to}
                 select={() => {}}
                 underline={false}
+                className="block w-full"
                 theme={theme}
                 size={size}
               />

--- a/frontend/src/components/uiParts/RouterLinkItem/presenter.tsx
+++ b/frontend/src/components/uiParts/RouterLinkItem/presenter.tsx
@@ -6,6 +6,7 @@ export interface RouterLinkItemProps {
   link: string
   select: (text: string) => void
   underline: boolean
+  className?: string
   theme: 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'normal' | 'white' | 'black'
   size: 'xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
 }
@@ -14,9 +15,15 @@ export const RouterLinkItem = (props: RouterLinkItemProps) => {
   const handleClick = () => props.select(props.text)
   const location = useLocation()
 
+  const linkClassName = ['font-medium', props.className].filter(Boolean).join(' ')
+
   return (
     <>
-      <Link data-testid="linkItem" onClick={handleClick} className="font-medium" to={props.link} 
+      <Link
+        data-testid="linkItem"
+        onClick={handleClick}
+        className={linkClassName}
+        to={props.link}
         state={{previousLocationPath: location.pathname, nextLocationPath: props.link}}>
         <TextMessage
           theme={props.theme}

--- a/frontend/src/components/uniqueParts/HeaderWithMenuLinks/HeaderWithMenuLinks.stories.tsx
+++ b/frontend/src/components/uniqueParts/HeaderWithMenuLinks/HeaderWithMenuLinks.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { HeaderWithMenuLinks } from './container'
+
+const meta: Meta<typeof HeaderWithMenuLinks> = {
+  title: 'Unique/HeaderWithMenuLinks',
+  component: HeaderWithMenuLinks,
+}
+
+export default meta
+type Story = StoryObj<typeof HeaderWithMenuLinks>
+
+export const Default: Story = {
+  args: {
+    title: {
+      appName: 'Forgetting Curve',
+      iconSrc: '/vite.svg',
+      iconAlt: 'app icon',
+      to: '/',
+    },
+    menuItems: [
+      { label: 'ホーム', to: '/' },
+      { label: '新規登録', to: '/learning-items/new' },
+      { label: '統計', to: '/statistics' },
+    ],
+  },
+  render: (args) => (
+    <MemoryRouter>
+      <HeaderWithMenuLinks {...args} />
+    </MemoryRouter>
+  ),
+}

--- a/frontend/src/components/uniqueParts/HeaderWithMenuLinks/container.tsx
+++ b/frontend/src/components/uniqueParts/HeaderWithMenuLinks/container.tsx
@@ -1,0 +1,23 @@
+import type { HeaderTitleProps } from '../../uiParts/HeaderTitle'
+import type { HeaderMenuItem, HeaderMenuProps } from '../../uiParts/HeaderMenu'
+import { HeaderWithMenuLinksPresenter } from './presenter'
+
+export interface HeaderWithMenuLinksProps {
+  title: HeaderTitleProps
+  menuItems: HeaderMenuItem[]
+  menuTheme?: HeaderMenuProps['theme']
+  menuSize?: HeaderMenuProps['size']
+}
+
+export const HeaderWithMenuLinks = (props: HeaderWithMenuLinksProps) => {
+  return (
+    <HeaderWithMenuLinksPresenter
+      title={props.title}
+      menu={{
+        items: props.menuItems,
+        theme: props.menuTheme,
+        size: props.menuSize,
+      }}
+    />
+  )
+}

--- a/frontend/src/components/uniqueParts/HeaderWithMenuLinks/index.ts
+++ b/frontend/src/components/uniqueParts/HeaderWithMenuLinks/index.ts
@@ -1,0 +1,1 @@
+export { HeaderWithMenuLinks } from './container'

--- a/frontend/src/components/uniqueParts/HeaderWithMenuLinks/presenter.test.tsx
+++ b/frontend/src/components/uniqueParts/HeaderWithMenuLinks/presenter.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { HeaderWithMenuLinksPresenter } from './presenter'
+
+describe('HeaderWithMenuLinksPresenter', () => {
+  it('タイトルリンク + メニューリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <HeaderWithMenuLinksPresenter
+          title={{
+            appName: 'Forgetting Curve',
+            iconSrc: '/dummy.svg',
+            iconAlt: 'app icon',
+            to: '/',
+          }}
+          menu={{
+            items: [
+              { label: 'ホーム', to: '/' },
+              { label: '新規登録', to: '/learning-items/new' },
+              { label: '統計', to: '/statistics' },
+            ],
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const links = screen.getAllByRole('link')
+    expect(links.length).toBe(4)
+
+    expect(screen.getByRole('link', { name: 'Forgetting Curve' }).getAttribute('href')).toBe('/')
+    expect(screen.getByRole('link', { name: 'ホーム' }).getAttribute('href')).toBe('/')
+    expect(screen.getByRole('link', { name: '新規登録' }).getAttribute('href')).toBe('/learning-items/new')
+    expect(screen.getByRole('link', { name: '統計' }).getAttribute('href')).toBe('/statistics')
+  })
+
+  it('nav に aria-label="Header menu" が付与される', () => {
+    render(
+      <MemoryRouter>
+        <HeaderWithMenuLinksPresenter
+          title={{
+            appName: 'Forgetting Curve',
+            iconSrc: '/dummy.svg',
+            iconAlt: 'app icon',
+          }}
+          menu={{ items: [{ label: 'ホーム', to: '/' }] }}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('navigation', { name: 'Header menu' })).toBeTruthy()
+  })
+})

--- a/frontend/src/components/uniqueParts/HeaderWithMenuLinks/presenter.tsx
+++ b/frontend/src/components/uniqueParts/HeaderWithMenuLinks/presenter.tsx
@@ -1,0 +1,19 @@
+import { Header } from '../../uiParts/Header'
+import { HeaderMenu, type HeaderMenuProps } from '../../uiParts/HeaderMenu'
+import { HeaderTitle, type HeaderTitleProps } from '../../uiParts/HeaderTitle'
+
+export interface HeaderWithMenuLinksPresenterProps {
+  title: HeaderTitleProps
+  menu: HeaderMenuProps
+}
+
+export const HeaderWithMenuLinksPresenter = (props: HeaderWithMenuLinksPresenterProps) => {
+  return (
+    <Header>
+      <HeaderTitle {...props.title} />
+      <div className="flex-1 pr-4">
+        <HeaderMenu {...props.menu} />
+      </div>
+    </Header>
+  )
+}


### PR DESCRIPTION
- Closes #2
- HeaderWithMenuLinks（container/presenter）追加
- HeaderMenu を均等割表示に調整
  - [header.md](vscode-file://vscode-app/c:/Users/norin/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) に均等割仕様を追記
- lint/test: OK